### PR TITLE
style for custom containers

### DIFF
--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -29,3 +29,74 @@ body:not(.theme-dark) div[class*='language-'] pre, body.theme-light div[class*='
     .feature
       p
         text-align left !important
+
+// custom containters
+body:not(.theme-dark)
+  .custom-block
+    padding 2px 20px 2px 20px
+    text-align justify
+    &.danger 
+      border-left 5px solid #cc0000 
+      background-color #ffe6e6 
+      color #4d0000
+      .custom-block-title 
+        color #990000 
+        font-weight bold
+        font-family sans-serif
+    &.tip 
+      border-left 5px solid #42b983
+      background-color #f3f5f7
+      color #2c3e50
+      .custom-block-title 
+        color #2c3e50
+        font-weight bold
+        font-family sans-serif
+    &.warning
+      border-left: 5px solid #e7c000
+      background-color #fff7d0
+      color #6b5900
+      .custom-block-title 
+        color #b29400
+        font-weight bold
+        font-family sans-serif
+
+body:not(.theme-light)
+  .custom-block
+    padding 2px 20px 2px 20px
+    text-align justify
+    &.danger 
+      border-left 5px solid #cc0000 
+      background-color #e6cfcf 
+      color #4d0000
+      .custom-block-title 
+        color #990000 
+        font-weight bold
+        font-family sans-serif
+    &.tip 
+      border-left 5px solid #42b983
+      background-color #f3f5f7
+      color #2c3e50
+      .custom-block-title 
+        color #2c3e50
+        font-weight bold
+        font-family sans-serif
+    &.warning
+      border-left: 5px solid #e7c000
+      background-color #fff8d5
+      color #6b5900
+      .custom-block-title 
+        color #b29400
+        font-weight bold
+        font-family sans-serif
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Hi, there. 
I found custom containers in the vuepress documentation, but because we use a custom theme, they are not displayed according to this documentation. [Link for custom containers in vuepress doc](https://v1.vuepress.vuejs.org/guide/markdown.html#custom-containers).

Therefore, I added style to those custom containers to make them pretty again.

Without styles:
![image](https://user-images.githubusercontent.com/58347555/124890619-83142e80-dfd8-11eb-91aa-28eed2e76126.png)

With styles:
![image](https://user-images.githubusercontent.com/58347555/124890766-ab039200-dfd8-11eb-9f81-75a942bac3f8.png)

In darkmode:
![image](https://user-images.githubusercontent.com/58347555/124890895-c7073380-dfd8-11eb-9049-915da2db5b09.png)

I copied the light mode styles from the documentation. For dark mode, I just chose a darker background.

If you want to add custom title:
![image](https://user-images.githubusercontent.com/58347555/124892113-dd61bf00-dfd9-11eb-9066-4c4462c09acd.png)

In docs:
![image](https://user-images.githubusercontent.com/58347555/124892227-f9fdf700-dfd9-11eb-9d54-132722f994fc.png)
