### PR TITLE
FileExplorer: document missing and new features

### DIFF
--- a/src/en/developer-guide/applications/controls/FileExplorer/collaborationworkspaces.md
+++ b/src/en/developer-guide/applications/controls/FileExplorer/collaborationworkspaces.md
@@ -78,7 +78,7 @@ The following settings individually control whether each action is available to 
 | **Details Pane Enabled** | Info panel (file metadata) |
 | **New Document Enabled** | New folder, new document, from template |
 
-Ask WAS for help if needed.
+If you need help, [open an issue](https://github.com/TALXIS/client-controls/issues/new/choose).
 
 
 

--- a/src/en/developer-guide/applications/controls/FileExplorer/collaborationworkspaces.md
+++ b/src/en/developer-guide/applications/controls/FileExplorer/collaborationworkspaces.md
@@ -41,6 +41,9 @@ Each configuration has an explanation written below it.
 - **Default Opener:** Set the primary way to open documents such as Word, Excel, PowerPoint.
 - **File Explorer Mode:** Path/List. Only Path is currently supported.
 - **File Explorer Provider:** Sharepoint/Environment File System. Only Sharepoint is currently supported.
+- **Template Type:** Controls how the _Graph Filter Query_ field is interpreted when locating the SharePoint storage target. Available values:
+  - **M365 Group** _(default)_ — `talxis_graphfilterquery` is an OData group `$filter` (e.g. `mail eq 'hr@contoso.com'`). The control finds the M365 group and opens its backing SharePoint team site.
+  - **SPO Site** — `talxis_graphfilterquery` is a direct site locator: an absolute URL, a server-relative path, or a bare site name (e.g. `hr`, `/sites/hr`, or `https://contoso.sharepoint.com/sites/hr`). Use this for Communication Sites or any SharePoint site that is not backed by an M365 group.
 - **Show Root Folder Name:** Use this field if you do not want to display the folder name if the user's current working directory is set to root of the _File Explorer_ control instance.
 - **Root Folder Name:** Use this field if you do not want to display the name of the last folder in the path.
 - **Lock on Disable:** If you wish to disable some functionality, such as recording or deleting, on inactive records, select Yes here.
@@ -50,9 +53,30 @@ Each configuration has an explanation written below it.
 - **Event Handlers:** Support for this functionality will be added in future releases.
 - **Expand Query:** The query to get data from related records of the source record the _File Explorer_ control instance is bound to. Contact your administrator for setup help.
 - **Folder Path:** The path to the destination folder in Sharepoint Online. Separate folders with '/'. Path supports the LIQUID markup language. Contact your administrator for setup help.
-- **Graph Filter Query:** A filter used by the File Explorer to correctly find the target site in Sharepoint Online. Contact your administrator for setup help.
+- **Graph Filter Query:** Locates the SharePoint storage target. Its meaning depends on the _Template Type_ setting — see above. Supports Liquid templating against the source record. Contact your administrator for setup help.
+- **Drive Filter:** The name of the SharePoint document library (Graph _drive_) to open. When empty, the site's default document library is used. Matching is case-insensitive — exact name match is tried first, then substring. Use this when the target site contains multiple document libraries and you need to open a specific one.
 - **Form ID:** Enter the main form ID for the file metadata here. Default value is 357117a8-ac48-ee11-be6d-000d3adc1f33.
 - **File Record Expand Query:** It is possible to expand file record with related data for custom view columns. Typically this will be used for files related to a specific record such as contract through `talxis_regardingobjectid` lookup.
+
+#### Action Visibility
+
+The following settings individually control whether each action is available to users. Setting a field to **No** hides the corresponding button(s) entirely, regardless of the _Lock on Disable_ setting.
+
+| Setting | Controls |
+| ------- | -------- |
+| **Sharing Enabled** | Copy link, Add people & send |
+| **Delete Enabled** | Delete file or folder |
+| **Rename Enabled** | Rename file or folder |
+| **Move To Enabled** | Move To |
+| **Copy To Enabled** | Copy To |
+| **Download Enabled** | Download (file as-is and PDF) |
+| **Convert Enabled** | Convert to PDF / ZIP archive |
+| **Versioning Enabled** | Check Out / Check In, Show history |
+| **E-Signature Enabled** | E-Signature actions |
+| **ZIP Archive Enabled** | ZIP archive creation |
+| **Upload Enabled** | Upload from device |
+| **Details Pane Enabled** | Info panel (file metadata) |
+| **New Document Enabled** | New folder, new document, from template |
 
 Ask WAS for help if needed.
 

--- a/src/en/developer-guide/applications/controls/FileExplorer/custom-command-bar-buttons.md
+++ b/src/en/developer-guide/applications/controls/FileExplorer/custom-command-bar-buttons.md
@@ -26,17 +26,29 @@ Here you add a new button (record) to the existing _File Explorer_ control insta
 | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Action                          | Action that should happen once the button is clicked on. See [available actions](#action-type-codes).                                                                                                                                         |
 | On-demand Workflow / Flow Id \* | Id of the on-demand workflow or flow you wish to trigger. The triggering record is always the file you've triggered the action from.                                                                                                          |
+| Function Name \*\*              | Name of the JavaScript function to call. The function must be exported from the web resource specified in _Web Resource Name_.                                                                                                                |
+| Web Resource Name \*\*          | Logical name of the web resource that contains the function. The web resource is loaded dynamically when the button is clicked.                                                                                                               |
 | Shown When                      | When should be the button shown to the user in the UI. See [available values](#shown-when-type-codes).                                                                                                                                        |
+| Location                        | Where the button is rendered. See [available values](#button-location-type-codes). Defaults to _Header_ if not set.                                                                                                                          |
+| Order                           | Numeric value that controls the rendering order of buttons within their location. Lower numbers appear first.                                                                                                                                 |
 | File Name Filter                | Allows you to show the button only for a specific type of file. Example: `*.*` allows to select only files and not folders. There is [`minimatch`](https://www.npmjs.com/package/minimatch) library used for evaluation of these expressions. |
 
-\* : Visible only if the _Action_ is set to _On-demand Workflow / Flow_ value.
+\* : Visible only if the _Action_ is set to _On-demand Workflow / Flow_ value.  
+\*\* : Visible only if the _Action_ is set to _Script_ value.
 
 ##### Action Type Codes
-| Name                      | Value     | Description                                                                                  |
-| ------------------------- | --------- | -------------------------------------------------------------------------------------------- |
-| On-demand Workflow / Flow | 742070000 | Triggers an on-demand workflow or cloud flow. This action can't be awaited. Fire and forget. |
+| Name                      | Value     | Description                                                                                                                          |
+| ------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| On-demand Workflow / Flow | 742070000 | Triggers an on-demand workflow or cloud flow. This action can't be awaited. Fire and forget.                                         |
+| Script                    | 742070001 | Calls a JavaScript function exported from a web resource. Use _Function Name_ and _Web Resource Name_ to specify the target function. |
 
 If there is "your" action missing, feel free to extend this feature and implement it.
+
+##### Button Location Type Codes
+| Name    | Value     | Description                                                                 |
+| ------- | --------- | --------------------------------------------------------------------------- |
+| Header  | 742070000 | Button appears in the Header Command Bar (top of the control).              |
+| Context | 742070001 | Button appears inline on each file/folder row (Item Command Bar). |
 
 ##### Shown When Type Codes
 | Name          | Value     | Description                                            |

--- a/src/en/developer-guide/applications/controls/FileExplorer/documenttemplating.md
+++ b/src/en/developer-guide/applications/controls/FileExplorer/documenttemplating.md
@@ -56,4 +56,4 @@ Document Template records are once again matched using the Entity Name and Query
 - Document Templates needs to be properly setuped and published in order to be used in File Explorer.
 - Use Document Type records to further diversify and specify possibilities for users.
 - Try to enable File Classification for bottom levels of Document Types.
-- If you need help, ask WAS.
+- If you need help, [open an issue](https://github.com/TALXIS/client-controls/issues/new/choose).

--- a/src/en/developer-guide/applications/controls/FileExplorer/general.md
+++ b/src/en/developer-guide/applications/controls/FileExplorer/general.md
@@ -171,7 +171,7 @@ The control parameters are passed as a **JSON-encoded `data` query parameter**:
 | `recordId`                 | GUID of the record to use as the source context (equivalent to the form's record ID). Required.                                                              |
 | `entityLogicalName`        | Logical name of the entity the record belongs to (e.g. `account`). Required.                                                                                |
 | `collaborationWorkspaceId` | GUID of the _Collaboration Workspace Template_ record to use. If omitted, the control resolves a matching template automatically (same logic as on a form). |
-| `formId`                   | Optional override for the file metadata form ID.                                                                                                             |
+| `formId`                   | Optional. When provided, enables a **Download Reference Document** button in the template creation dialog. The value is a `systemform` record ID passed to the document generation service to produce a Word tag-reference document for template authors. Only needed when setting up document templates for this entity. |
 
 Additionally, `cmdbar=true&navbar=on` must be set. The authentication broker JavaScript is loaded via the ribbon, so disabling the command bar will break authentication.
 

--- a/src/en/developer-guide/applications/controls/FileExplorer/general.md
+++ b/src/en/developer-guide/applications/controls/FileExplorer/general.md
@@ -107,6 +107,8 @@ So for example in the screenshot above by clicking on "Contracts" you will go ba
 
 The general appearance is similar to the File Picker control. You can select items, and by using Drag & Drop, you can upload new files. In addition to the existing features in the File Picker control, a new column is available to display the **Version**.
 
+File names are **clickable** — a single click on a file name opens the file using the configured _Default Opener_. This is equivalent to using the _Open_ action from the Item Command Bar.
+
 #### Version
 
 The value is retrieved from SharePoint. Each time it is updated, the change is propagated to the connected talxis_file record where metadata is stored.
@@ -157,4 +159,21 @@ Learn how to properly setup File Explorer via [Collaboration Workspace Template]
 Browse through [capabilities](./actions.md) of this control **(WIP)**.
 
 Check [Document Templating](./documenttemplating.md) to learn how to generate files from the File Explorer.
+
+## Standalone Page
+
+File Explorer can be used as a full-page standalone control (not embedded on a record form) by navigating to a page with `pagetype=control`. This is useful for deep-linking directly into a specific folder context from another part of the application.
+
+The control reads its context from the following URL parameters:
+
+| Parameter                    | Description                                                                                   |
+| ---------------------------- | --------------------------------------------------------------------------------------------- |
+| `recordId`                   | GUID of the record to use as the source context (equivalent to the form's record ID).         |
+| `entityLogicalName`          | Logical name of the entity the record belongs to (e.g. `account`).                           |
+| `collaborationWorkspaceId`   | GUID of the _Collaboration Workspace Template_ record to use. If omitted, the control resolves a matching template automatically (same logic as on a form). |
+
+Example URL:
+```
+/main.aspx?pagetype=control&controlName=talxis_TALXIS.PCF.FileExplorer&recordId=<guid>&entityLogicalName=account
+```
 

--- a/src/en/developer-guide/applications/controls/FileExplorer/general.md
+++ b/src/en/developer-guide/applications/controls/FileExplorer/general.md
@@ -164,20 +164,20 @@ Check [Document Templating](./documenttemplating.md) to learn how to generate fi
 
 File Explorer can be used as a full-page standalone control (not embedded on a record form) by navigating to a page with `pagetype=control`. This is useful for deep-linking directly into a specific folder context from another part of the application.
 
-The control parameters are passed as a **JSON-encoded `data` query parameter**:
+The mandatory parameters are passed as a **JSON-encoded `data` query parameter**:
 
-| Parameter                  | Description                                                                                                                                                  |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `recordId`                 | GUID of the record to use as the source context (equivalent to the form's record ID). Required.                                                              |
-| `entityLogicalName`        | Logical name of the entity the record belongs to (e.g. `account`). Required.                                                                                |
-| `collaborationWorkspaceId` | GUID of the _Collaboration Workspace Template_ record to use. If omitted, the control resolves a matching template automatically (same logic as on a form). |
-| `formId`                   | Optional. When provided, enables a **Download Reference Document** button in the template creation dialog. The value is a `systemform` record ID passed to the document generation service to produce a Word tag-reference document for template authors. Only needed when setting up document templates for this entity. |
+| Parameter     | Description                                                              |
+| ------------- | ------------------------------------------------------------------------ |
+| `recordId`    | GUID of the record to use as the source context. Required.               |
+| `entityLogicalName` | Logical name of the entity the record belongs to (e.g. `account`). Required. |
+
+All other options (e.g. `collaborationWorkspaceId`, `formId`) follow the same conventions as when the control is used on a form — see [Collaboration Workspaces](./collaborationworkspaces.md) and [Document Templating](./documenttemplating.md).
 
 Additionally, `cmdbar=true&navbar=on` must be set. The authentication broker JavaScript is loaded via the ribbon, so disabling the command bar will break authentication.
 
 Example URL:
 ```
-https://<org>.crm4.dynamics.com/main.aspx?pagetype=control&controlName=talxis_TALXIS.PCF.FileExplorer&cmdbar=true&navbar=on&forceUCI=1&data={"collaborationWorkspaceId":"<guid>","entityLogicalName":"account","recordId":"<guid>"}
+https://<org>.crm4.dynamics.com/main.aspx?pagetype=control&controlName=talxis_TALXIS.PCF.FileExplorer&cmdbar=true&navbar=on&forceUCI=1&data={"entityLogicalName":"account","recordId":"<guid>"}
 ```
 
 ::: tip

--- a/src/en/developer-guide/applications/controls/FileExplorer/general.md
+++ b/src/en/developer-guide/applications/controls/FileExplorer/general.md
@@ -164,16 +164,24 @@ Check [Document Templating](./documenttemplating.md) to learn how to generate fi
 
 File Explorer can be used as a full-page standalone control (not embedded on a record form) by navigating to a page with `pagetype=control`. This is useful for deep-linking directly into a specific folder context from another part of the application.
 
-The control reads its context from the following URL parameters:
+The control parameters are passed as a **JSON-encoded `data` query parameter**:
 
-| Parameter                    | Description                                                                                   |
-| ---------------------------- | --------------------------------------------------------------------------------------------- |
-| `recordId`                   | GUID of the record to use as the source context (equivalent to the form's record ID).         |
-| `entityLogicalName`          | Logical name of the entity the record belongs to (e.g. `account`).                           |
-| `collaborationWorkspaceId`   | GUID of the _Collaboration Workspace Template_ record to use. If omitted, the control resolves a matching template automatically (same logic as on a form). |
+| Parameter                  | Description                                                                                                                                                  |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `recordId`                 | GUID of the record to use as the source context (equivalent to the form's record ID). Required.                                                              |
+| `entityLogicalName`        | Logical name of the entity the record belongs to (e.g. `account`). Required.                                                                                |
+| `collaborationWorkspaceId` | GUID of the _Collaboration Workspace Template_ record to use. If omitted, the control resolves a matching template automatically (same logic as on a form). |
+| `formId`                   | Optional override for the file metadata form ID.                                                                                                             |
+
+Additionally, `cmdbar=true&navbar=on` must be set so the command bar and navigation bar are rendered — without them the page layout breaks.
 
 Example URL:
 ```
-/main.aspx?pagetype=control&controlName=talxis_TALXIS.PCF.FileExplorer&recordId=<guid>&entityLogicalName=account
+https://<org>.crm4.dynamics.com/main.aspx?pagetype=control&controlName=talxis_TALXIS.PCF.FileExplorer&cmdbar=true&navbar=on&forceUCI=1&data={"collaborationWorkspaceId":"<guid>","entityLogicalName":"account","recordId":"<guid>"}
+```
+
+In practice the `data` value must be URL-encoded:
+```
+https://<org>.crm4.dynamics.com/main.aspx?pagetype=control&controlName=talxis_TALXIS.PCF.FileExplorer&cmdbar=true&navbar=on&forceUCI=1&data=%7B%22collaborationWorkspaceId%22%3A%22<guid>%22%2C%22entityLogicalName%22%3A%22account%22%2C%22recordId%22%3A%22<guid>%22%7D
 ```
 

--- a/src/en/developer-guide/applications/controls/FileExplorer/general.md
+++ b/src/en/developer-guide/applications/controls/FileExplorer/general.md
@@ -173,7 +173,7 @@ The control parameters are passed as a **JSON-encoded `data` query parameter**:
 | `collaborationWorkspaceId` | GUID of the _Collaboration Workspace Template_ record to use. If omitted, the control resolves a matching template automatically (same logic as on a form). |
 | `formId`                   | Optional override for the file metadata form ID.                                                                                                             |
 
-Additionally, `cmdbar=true&navbar=on` must be set so the command bar and navigation bar are rendered — without them the page layout breaks.
+Additionally, `cmdbar=true&navbar=on` must be set. The authentication broker JavaScript is loaded via the ribbon, so disabling the command bar will break authentication.
 
 Example URL:
 ```

--- a/src/en/developer-guide/applications/controls/FileExplorer/general.md
+++ b/src/en/developer-guide/applications/controls/FileExplorer/general.md
@@ -180,8 +180,7 @@ Example URL:
 https://<org>.crm4.dynamics.com/main.aspx?pagetype=control&controlName=talxis_TALXIS.PCF.FileExplorer&cmdbar=true&navbar=on&forceUCI=1&data={"collaborationWorkspaceId":"<guid>","entityLogicalName":"account","recordId":"<guid>"}
 ```
 
-In practice the `data` value must be URL-encoded:
-```
-https://<org>.crm4.dynamics.com/main.aspx?pagetype=control&controlName=talxis_TALXIS.PCF.FileExplorer&cmdbar=true&navbar=on&forceUCI=1&data=%7B%22collaborationWorkspaceId%22%3A%22<guid>%22%2C%22entityLogicalName%22%3A%22account%22%2C%22recordId%22%3A%22<guid>%22%7D
-```
+::: tip
+When constructing this URL programmatically (e.g. in a sitemap or JavaScript), URL-encode the `data` value. Browsers encode it automatically when the URL is pasted into the address bar.
+:::
 

--- a/src/en/developer-guide/applications/solution-components/form.md
+++ b/src/en/developer-guide/applications/solution-components/form.md
@@ -48,7 +48,7 @@ When you are creating forms with PowerApps editor there are nearly always duplic
 **TIP:**
 Use GUID swap script to get rid of them: [GUIDSwapIdCellsOnManagedForms](https://dev.azure.com/thenetworg/INT0006/_git/TALXIS?path=%2Fsrc%2FScripts%2FGuidSwapIdCellsOnManagedForms.ps1) 
 
-*WARNING: This script is not fully capable on solving all issues. There are also labelid GUIDs that you need to change too. Contact KOS or WAS for help.*
+*WARNING: This script is not fully capable on solving all issues. There are also labelid GUIDs that you need to change too. If you need help, [open an issue](https://github.com/TALXIS/client-controls/issues/new/choose).*
 ___
 
 

--- a/src/en/developer-guide/getting-started/devkit/devkit-vscode.md
+++ b/src/en/developer-guide/getting-started/devkit/devkit-vscode.md
@@ -106,6 +106,6 @@ Under each DevBox the is list of all unmanaged solutions. If there are none then
 - Existing Power Platform Environment with System Admin role.
 
 ## Logs
-In case something is not working correctly for you, please open TALXIS DevKit Logs in OUTPUT and send those logs for me (WAS) so I can troubleshoot what happend.
+In case something is not working correctly for you, please open TALXIS DevKit Logs in OUTPUT and [open an issue](https://github.com/TALXIS/client-controls/issues/new/choose) with the logs attached so we can troubleshoot what happened.
 
 ![DevKitLogs.png](/.attachments/DevKit/DevKitLogs.png)

--- a/src/en/developer-guide/getting-started/devkit/devkit-vscode.md
+++ b/src/en/developer-guide/getting-started/devkit/devkit-vscode.md
@@ -106,6 +106,6 @@ Under each DevBox the is list of all unmanaged solutions. If there are none then
 - Existing Power Platform Environment with System Admin role.
 
 ## Logs
-In case something is not working correctly for you, please open TALXIS DevKit Logs in OUTPUT and [open an issue](https://github.com/TALXIS/client-controls/issues/new/choose) with the logs attached so we can troubleshoot what happened.
+In case something is not working correctly for you, please open TALXIS DevKit Logs in OUTPUT and [open an issue](https://github.com/TALXIS/tools-cli/issues/new) with the logs attached so we can troubleshoot what happened.
 
 ![DevKitLogs.png](/.attachments/DevKit/DevKitLogs.png)

--- a/src/en/developer-guide/getting-started/devkit/troubleshooting.md
+++ b/src/en/developer-guide/getting-started/devkit/troubleshooting.md
@@ -41,5 +41,5 @@ Make sure to restart your PC if you just installed any of above required tooling
 	- Delete all DevKit folders in C:\Users\USERNAME\ .vscode\extensions\networg.talxis-sdk-devkit-vscode-(version)
 	- Do all from above
 	- Install DevKit
-8. **Lemme know (WAS)**
+8. **[Open an issue](https://github.com/TALXIS/client-controls/issues/new/choose)**
 	- If nothing helps please let me know.

--- a/src/en/developer-guide/getting-started/devkit/troubleshooting.md
+++ b/src/en/developer-guide/getting-started/devkit/troubleshooting.md
@@ -41,5 +41,5 @@ Make sure to restart your PC if you just installed any of above required tooling
 	- Delete all DevKit folders in C:\Users\USERNAME\ .vscode\extensions\networg.talxis-sdk-devkit-vscode-(version)
 	- Do all from above
 	- Install DevKit
-8. **[Open an issue](https://github.com/TALXIS/client-controls/issues/new/choose)**
+8. **[Open an issue](https://github.com/TALXIS/tools-cli/issues/new)**
 	- If nothing helps please let me know.


### PR DESCRIPTION
## Summary

Documents missing and new File Explorer features identified by analyzing recent commits to `INT0015/src/controls/FileExplorer`.

### `collaborationworkspaces.md`
- **Template Type** — explains M365 Group vs SPO Site and how each affects the _Graph Filter Query_ field interpretation
- **Drive Filter** — new field to specify a named SharePoint document library
- Updated **Graph Filter Query** description to reference Template Type
- **Action Visibility table** — documents all 13 individual enable/disable toggles (Sharing, Delete, Rename, Move To, Copy To, Download, Convert, Versioning, E-Signature, ZIP Archive, Upload, Details Pane, New Document)

### `custom-command-bar-buttons.md`
- **Script** action type (value `742070001`) with two conditional fields: _Function Name_ and _Web Resource Name_
- **Button Location** field (Header / Context inline) with its own type codes table
- **Order** field for numeric button ordering

### `general.md`
- Note that file names are single-click to open
- New **Standalone Page** section documenting `pagetype=control` with URL parameters (`recordId`, `entityLogicalName`, `collaborationWorkspaceId`)